### PR TITLE
[Feature] RabbitMQ 메세지 멱등성 보장 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
     implementation 'com.slack.api:slack-api-client:1.40.0'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/wegotoo/sse/api/sse/SseController.java
+++ b/src/main/java/com/wegotoo/sse/api/sse/SseController.java
@@ -4,7 +4,10 @@ import com.wegotoo.sse.application.sse.SseService;
 import com.wegotoo.sse.event.notification.request.NotificationMessage;
 import com.wegotoo.sse.infra.resolvers.Auth;
 import java.util.Random;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,6 +17,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class SseController {
 
     private final SseService sseService;
@@ -27,23 +31,6 @@ public class SseController {
     @GetMapping(value = "/v1/sse/{userId}", produces = "text/event-stream")
     public SseEmitter connectionCopy(@PathVariable Long userId) {
         return sseService.connect(userId);
-    }
-
-    @PostMapping(value = "/v1/send/{userId}")
-    public void sendMessage(@PathVariable Long userId) {
-        Random random = new Random();
-        long randomNumber = random.nextInt(98) + 2;
-
-        NotificationMessage message = NotificationMessage.builder()
-                .fromId(randomNumber)
-                .fromName("USER_" + randomNumber)
-                .toId(userId)
-                .toName("USER_" + userId)
-                .event("COMMENT")
-                .message("USER_" + randomNumber + "님이 댓글을 남겼습니다.")
-                .build();
-
-        rabbitTemplate.convertAndSend("app.sse", "sse", message);
     }
 
 }

--- a/src/main/java/com/wegotoo/sse/config/RedisConfig.java
+++ b/src/main/java/com/wegotoo/sse/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.wegotoo.sse.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.cache.CacheProperties.Redis;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+
+        redisStandaloneConfiguration.setHostName(redisProperties.getHost());
+        redisStandaloneConfiguration.setPort(redisProperties.getPort());
+
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(LettuceConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/wegotoo/sse/event/notification/NotificationMessageListener.java
+++ b/src/main/java/com/wegotoo/sse/event/notification/NotificationMessageListener.java
@@ -9,6 +9,7 @@ import static com.wegotoo.sse.infra.utils.SseMessagePath.RETRY_ROUTING_KEY;
 import com.rabbitmq.client.Channel;
 import com.wegotoo.sse.application.sse.SseService;
 import com.wegotoo.sse.event.notification.request.NotificationMessage;
+import com.wegotoo.sse.infra.idempotency.Idempotent;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -27,10 +28,14 @@ public class NotificationMessageListener {
     private static final int MAX_RETRIES = 3;
     private static final String RETRY_COUNT_HEADER = "x-retry-count";
 
+    @Idempotent
     @RabbitListener(queues = MAIN_QUEUE_NAME)
     public void handleNotificationMessage(
-            NotificationMessage notificationMessage, Channel channel,
+            Channel channel,
+            NotificationMessage notificationMessage,
             @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag,
+            @Header(AmqpHeaders.MESSAGE_ID) String messageId,
+            @Header(AmqpHeaders.CORRELATION_ID) String correlationId,
             @Header(name = RETRY_COUNT_HEADER, required = false, defaultValue = "0") Integer retryCount
     ) throws IOException {
         try {
@@ -40,7 +45,7 @@ public class NotificationMessageListener {
             if (retryCount >= MAX_RETRIES) {
                 sendToDLQ(notificationMessage);
             } else {
-                sendToRetryQueue(notificationMessage, retryCount);
+                sendToRetryQueue(notificationMessage, retryCount, messageId, correlationId);
             }
 
             channel.basicAck(deliveryTag, false);
@@ -51,13 +56,18 @@ public class NotificationMessageListener {
         rabbitTemplate.convertAndSend(DLX_NAME, DLQ_ROUTING_KEY, notificationMessage);
     }
 
-    private void sendToRetryQueue(NotificationMessage notificationMessage, int currentRetryCount) {
+    private void sendToRetryQueue(NotificationMessage notificationMessage, int currentRetryCount, String messageId,
+                                  String correlationId) {
         final int newRetryCount = currentRetryCount + 1;
 
         rabbitTemplate.convertAndSend(MAIN_EXCHANGE_NAME, RETRY_ROUTING_KEY,
                 notificationMessage, msg -> {
                     msg.getMessageProperties().getHeaders().put(RETRY_COUNT_HEADER, newRetryCount);
+                    msg.getMessageProperties().setMessageId(messageId);
+                    msg.getMessageProperties().setCorrelationId(correlationId);
+
                     return msg;
                 });
     }
+
 }

--- a/src/main/java/com/wegotoo/sse/event/notification/request/NotificationMessage.java
+++ b/src/main/java/com/wegotoo/sse/event/notification/request/NotificationMessage.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationMessage {
 
+    private Long id;
     private Long fromId;
     private Long toId;
     private String fromName;
@@ -17,7 +18,9 @@ public class NotificationMessage {
     private String message;
 
     @Builder
-    private NotificationMessage(Long fromId, Long toId, String fromName, String toName, String event, String message) {
+    private NotificationMessage(Long id, Long fromId, Long toId, String fromName, String toName, String event,
+                                String message) {
+        this.id = id;
         this.fromId = fromId;
         this.toId = toId;
         this.fromName = fromName;

--- a/src/main/java/com/wegotoo/sse/exception/IdempotencyException.java
+++ b/src/main/java/com/wegotoo/sse/exception/IdempotencyException.java
@@ -1,0 +1,15 @@
+package com.wegotoo.sse.exception;
+
+import com.wegotoo.sse.infra.idempotency.IdempotentRepository;
+import lombok.Getter;
+
+@Getter
+public class IdempotencyException extends RuntimeException {
+
+    private final String messageId;
+
+    public IdempotencyException(String messageId) {
+        this.messageId = messageId;
+    }
+
+}

--- a/src/main/java/com/wegotoo/sse/infra/idempotency/Idempotent.java
+++ b/src/main/java/com/wegotoo/sse/infra/idempotency/Idempotent.java
@@ -1,0 +1,4 @@
+package com.wegotoo.sse.infra.idempotency;
+
+public @interface Idempotent {
+}

--- a/src/main/java/com/wegotoo/sse/infra/idempotency/IdempotentAspect.java
+++ b/src/main/java/com/wegotoo/sse/infra/idempotency/IdempotentAspect.java
@@ -1,0 +1,65 @@
+package com.wegotoo.sse.infra.idempotency;
+
+import com.rabbitmq.client.Channel;
+import com.wegotoo.sse.exception.IdempotencyException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IdempotentAspect {
+
+    private final IdempotentRepository idempotentRepository;
+
+    @Around("@annotation(com.wegotoo.sse.infra.idempotency.Idempotent)")
+    public Object validateIdempotency(ProceedingJoinPoint joinPoint) throws Throwable {
+        Map<String, Object> parameters = getParameters(joinPoint);
+
+        String messageId = getParameter(parameters, "messageId", String.class);
+        String correlationId = getParameter(parameters, "correlationId", String.class);
+
+        Boolean isSet = idempotentRepository.setIfAbsent(messageId, correlationId);
+        if (isSet) {
+            return joinPoint.proceed();
+        }
+
+        String storedCorrelationId = idempotentRepository.findByMessageId(messageId);
+        if (Objects.equals(correlationId, storedCorrelationId)) {
+            return joinPoint.proceed();
+        }
+
+        long deliveryTag = getParameter(parameters, "deliveryTag", Long.class);
+        Channel channel = getParameter(parameters, "channel", Channel.class);
+
+        channel.basicAck(deliveryTag, false);
+        throw new IdempotencyException(messageId);
+    }
+
+    private <T> T getParameter(Map<String, Object> parameters, String key, Class<T> clazz) {
+        Object value = parameters.get(key);
+        return clazz.cast(value);
+    }
+
+    private Map<String, Object> getParameters(JoinPoint joinPoint) {
+        Map<String, Object> parameters = new HashMap<>();
+
+        Object[] args = joinPoint.getArgs();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] parameterNames = signature.getParameterNames();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            parameters.put(parameterNames[i], args[i]);
+        }
+
+        return parameters;
+    }
+}

--- a/src/main/java/com/wegotoo/sse/infra/idempotency/IdempotentRepository.java
+++ b/src/main/java/com/wegotoo/sse/infra/idempotency/IdempotentRepository.java
@@ -1,0 +1,22 @@
+package com.wegotoo.sse.infra.idempotency;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IdempotentRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public String findByMessageId(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public Boolean setIfAbsent(String key, String value) {
+        return redisTemplate.opsForValue().setIfAbsent(key, value, Duration.ofMinutes(1));
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,8 +5,14 @@ spring:
 
   application:
     name: wegotoo_sse
+
   rabbitmq:
     host: localhost
     port: 5672
     username: guest
     password: guest
+
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
## 💡 연관된 이슈
close #5 

## 📝 작업 내용
- RabbitMQ 메세지 처리 시 발생할 수 있는 중복 수신 문제를 해결하기 위해 Redis를 사용한 멱등성 보장 로직을 구현했습니다. 
- AOP를 활용하여 메세지 처리 메서드에 멱등성 검사 로직을 적용했습니다. 
- Redis 연결을 위한 설정을 추가했습니다. 

## 💬 리뷰 요구 사항